### PR TITLE
Create setupProxy.js

### DIFF
--- a/frontend/setupProxy.js
+++ b/frontend/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+module.exports = function (app) {
+  app.use(
+    "/api/users/",
+    createProxyMiddleware({
+      target: "http://localhost:5000",
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
fix: How to setup proxy for node users with version >17.0.0 because proxy in the package.json produces this error(Invalid options object. Dev Server has been initialized using an options object that does not match the API schema. [1] - options.allowedHosts[0] should be a non-empty string.)